### PR TITLE
Feature/install k8s (#5)

### DIFF
--- a/vagrant/virtualbox_setup/my-k8s-cluster.yaml
+++ b/vagrant/virtualbox_setup/my-k8s-cluster.yaml
@@ -6,6 +6,6 @@ localAPIEndpoint:
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 networking:
-  podSubnet: "10.244.0.0/24"
+  podSubnet: "10.244.0.0/16"
 kubernetesVersion: "v1.26.0"
 clusterName: "my-k8s-cluster"


### PR DESCRIPTION
* initial version of k8s install

* updated kubeadm init config file

* corrected vagrantfile link

* Completed cp and worker install

* replaced pod-cidr-address

* Delete admin.conf

* initial version of kubeadm install

* added issues encountered

* Change pod-cidr-network to /16

To fix the no podcidr error when using the kubeadm init config file